### PR TITLE
Move handling of touchscreen gestures to a specific interface, add support for Samsung touchscreens

### DIFF
--- a/system/bus.c
+++ b/system/bus.c
@@ -9,6 +9,7 @@
 
 #include "gestures.h"
 #include "gestures-xiaomi.h"
+#include "gestures-sec.h"
 
 #define ADISHATZ_DBUS_NAME "org.droidian.MobileSettings"
 #define ADISHATZ_DBUS_PATH "/org/adishatz/MobileSettings"
@@ -197,6 +198,8 @@ bus_init (Bus *self)
 
     if (gestures_xiaomi_supported ())
         self->priv->gestures = (Gestures *) gestures_xiaomi_new ();
+    else if (gestures_sec_supported ())
+        self->priv->gestures = (Gestures *) gestures_sec_new ();
     else
         self->priv->gestures = NULL;
 }

--- a/system/gestures-sec.c
+++ b/system/gestures-sec.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright Eugenio Paolantonio (g7) <me@medesimo.eu>
+ */
+
+#define G_LOG_DOMAIN "gestures-sec"
+
+#include <unistd.h>
+
+#include "gestures.h"
+#include "gestures-sec.h"
+
+#include "../common/utils.h"
+
+#define SEC_CMD_LIST  "/sys/devices/virtual/sec/tsp/cmd_list"
+#define SEC_CMD       "/sys/devices/virtual/sec/tsp/cmd"
+#define PANEL_PRE_SOD "/sys/devices/dsi_panel_driver/pre_sod_mode"
+
+struct _GesturesSec
+{
+    GObject parent_instance;
+
+    gboolean double_tap_supported;
+    gboolean double_tap_enabled;
+};
+
+typedef enum {
+    GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED = 1,
+    GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_ENABLED,
+    GESTURES_SEC_PROP_LAST
+} GesturesSecProperty;
+
+static void gestures_sec_interface_init (GesturesInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (GesturesSec, gestures_sec, G_TYPE_OBJECT,
+                            G_IMPLEMENT_INTERFACE (TYPE_GESTURES,
+                                gestures_sec_interface_init))
+
+static void
+probe_features (GesturesSec *self)
+{
+    g_autofree gchar *cmd_list = NULL;
+    g_autoptr(GError) error = NULL;
+    gchar **lines;
+
+    if (!g_file_get_contents (SEC_CMD_LIST, &cmd_list, NULL, &error)) {
+        g_warning ("Unable to read SEC command list file: %s", error->message);
+        return;
+    }
+
+    lines = g_strsplit (cmd_list, "\n", -1);
+    for (guint i = 0; i < g_strv_length (lines); i++) {
+        if (g_strcmp0 (lines[i], "sod_enable") == 0) {
+            self->double_tap_supported = TRUE;
+            break;
+        }
+    }
+
+    g_strfreev (lines);
+}
+
+static void
+set_double_tap (gboolean double_tap)
+{
+    g_debug ("Changing double_tap setting: %d", double_tap);
+    write_to_file (SEC_CMD, double_tap ? "sod_enable,1" : "sod_enable,0");
+
+    if (access (PANEL_PRE_SOD, F_OK) == 0)
+        write_to_file (PANEL_PRE_SOD, double_tap ? "1" : "0");
+}
+
+static void
+gestures_sec_constructed (GObject *obj)
+{
+    GesturesSec *self = GESTURES_SEC (obj);
+
+    G_OBJECT_CLASS (gestures_sec_parent_class)->constructed (obj);
+
+    self->double_tap_supported = FALSE;
+    self->double_tap_enabled = FALSE;
+
+    probe_features (self);
+}
+
+static void
+gestures_sec_dispose (GObject *obj)
+{
+    G_OBJECT_CLASS (gestures_sec_parent_class)->dispose (obj);
+}
+
+static void
+gestures_sec_set_property (GObject      *obj,
+                           uint         property_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+    GesturesSec *self = GESTURES_SEC (obj);
+    gboolean bool_value;
+
+    switch ((GesturesSecProperty) property_id)
+        {
+        case GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_ENABLED:
+            bool_value =  g_value_get_boolean (value);
+            set_double_tap (bool_value);
+            self->double_tap_enabled = bool_value;
+            break;
+
+        case GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED:
+        case GESTURES_SEC_PROP_LAST:
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, property_id, pspec);
+            break;
+        }
+
+}
+
+static void
+gestures_sec_get_property (GObject    *obj,
+                           uint       property_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+    GesturesSec *self = GESTURES_SEC (obj);
+
+    switch ((GesturesSecProperty) property_id)
+        {
+        case GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED:
+            g_value_set_boolean (value, self->double_tap_supported);
+            break;
+
+        case GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_ENABLED:
+            g_value_set_boolean (value, self->double_tap_enabled);
+            break;
+
+        case GESTURES_SEC_PROP_LAST:
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, property_id, pspec);
+            break;
+        }
+
+}
+
+static void
+gestures_sec_class_init (GesturesSecClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->constructed  = gestures_sec_constructed;
+    object_class->dispose      = gestures_sec_dispose;
+    object_class->set_property = gestures_sec_set_property;
+    object_class->get_property = gestures_sec_get_property;
+
+    g_object_class_override_property (object_class, GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED,
+                                      "double-tap-to-wake-supported");
+    g_object_class_override_property (object_class, GESTURES_SEC_PROP_DOUBLE_TAP_TO_WAKE_ENABLED,
+                                      "double-tap-to-wake-enabled");
+}
+
+static void
+gestures_sec_interface_init (GesturesInterface *iface)
+{}
+
+static void
+gestures_sec_init (GesturesSec *self)
+{}
+
+GesturesSec *
+gestures_sec_new (void)
+{
+    return g_object_new (TYPE_GESTURES_SEC, NULL);
+}
+
+gboolean
+gestures_sec_supported (void)
+{
+    if (access (SEC_CMD_LIST, F_OK) == 0)
+        return TRUE;
+
+    return FALSE;
+}

--- a/system/gestures-sec.h
+++ b/system/gestures-sec.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright Eugenio Paolantonio (g7) <me@medesimo.eu>
+ */
+
+#ifndef GESTURESSEC_H
+#define GESTURESSEC_H
+
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define TYPE_GESTURES_SEC gestures_sec_get_type ()
+G_DECLARE_FINAL_TYPE (GesturesSec, gestures_sec, GESTURES, SEC, GObject)
+
+GesturesSec *gestures_sec_new (void);
+gboolean gestures_sec_supported (void);
+
+G_END_DECLS
+
+#endif /* GESTURESSEC_H */

--- a/system/gestures-xiaomi.c
+++ b/system/gestures-xiaomi.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright Eugenio Paolantonio (g7) <me@medesimo.eu>
+ * Copyright Cedric Bellegarde <cedric.bellegarde@adishatz.org>
+ */
+
+#define G_LOG_DOMAIN "gestures-xiaomi"
+
+#include <unistd.h>
+
+#include "gestures.h"
+#include "gestures-xiaomi.h"
+
+#include "../common/utils.h"
+
+#define TOUCHPANEL_DT2W_NODE "/sys/touchpanel/double_tap"
+
+struct _GesturesXiaomi
+{
+    GObject parent_instance;
+
+    gboolean double_tap_supported;
+    gboolean double_tap_enabled;
+};
+
+typedef enum {
+    GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED = 1,
+    GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_ENABLED,
+    GESTURES_XIAOMI_PROP_LAST
+} GesturesXiaomiProperty;
+
+static void gestures_xiaomi_interface_init (GesturesInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (GesturesXiaomi, gestures_xiaomi, G_TYPE_OBJECT,
+                            G_IMPLEMENT_INTERFACE (TYPE_GESTURES,
+                                gestures_xiaomi_interface_init))
+
+static void
+set_double_tap (gboolean double_tap)
+{
+    g_autofree gchar *value = NULL;
+
+    value = g_strdup_printf ("%d", double_tap);
+    g_debug ("Changing double_tap setting: %d", double_tap);
+
+    write_to_file (TOUCHPANEL_DT2W_NODE, value);
+}
+
+static void
+gestures_xiaomi_constructed (GObject *obj)
+{
+    GesturesXiaomi *self = GESTURES_XIAOMI (obj);
+
+    G_OBJECT_CLASS (gestures_xiaomi_parent_class)->constructed (obj);
+
+    self->double_tap_supported = (access (TOUCHPANEL_DT2W_NODE, F_OK) == 0);
+    self->double_tap_enabled = FALSE;
+}
+
+static void
+gestures_xiaomi_dispose (GObject *obj)
+{
+    G_OBJECT_CLASS (gestures_xiaomi_parent_class)->dispose (obj);
+}
+
+static void
+gestures_xiaomi_set_property (GObject      *obj,
+                              uint         property_id,
+                              const GValue *value,
+                              GParamSpec   *pspec)
+{
+    GesturesXiaomi *self = GESTURES_XIAOMI (obj);
+    gboolean bool_value;
+
+    switch ((GesturesXiaomiProperty) property_id)
+        {
+        case GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_ENABLED:
+            bool_value =  g_value_get_boolean (value);
+            set_double_tap (bool_value);
+            self->double_tap_enabled = bool_value;
+            break;
+
+        case GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED:
+        case GESTURES_XIAOMI_PROP_LAST:
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, property_id, pspec);
+            break;
+        }
+
+}
+
+static void
+gestures_xiaomi_get_property (GObject    *obj,
+                              uint       property_id,
+                              GValue     *value,
+                              GParamSpec *pspec)
+{
+    GesturesXiaomi *self = GESTURES_XIAOMI (obj);
+
+    switch ((GesturesXiaomiProperty) property_id)
+        {
+        case GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED:
+            g_value_set_boolean (value, self->double_tap_supported);
+            break;
+
+        case GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_ENABLED:
+            g_value_set_boolean (value, self->double_tap_enabled);
+            break;
+
+        case GESTURES_XIAOMI_PROP_LAST:
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, property_id, pspec);
+            break;
+        }
+
+}
+
+static void
+gestures_xiaomi_class_init (GesturesXiaomiClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+    object_class->constructed  = gestures_xiaomi_constructed;
+    object_class->dispose      = gestures_xiaomi_dispose;
+    object_class->set_property = gestures_xiaomi_set_property;
+    object_class->get_property = gestures_xiaomi_get_property;
+
+    g_object_class_override_property (object_class, GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_SUPPORTED,
+                                                                        "double-tap-to-wake-supported");
+    g_object_class_override_property (object_class, GESTURES_XIAOMI_PROP_DOUBLE_TAP_TO_WAKE_ENABLED,
+                                                                        "double-tap-to-wake-enabled");
+}
+
+static void
+gestures_xiaomi_interface_init (GesturesInterface *iface)
+{}
+
+static void
+gestures_xiaomi_init (GesturesXiaomi *self)
+{}
+
+GesturesXiaomi *
+gestures_xiaomi_new (void)
+{
+    return g_object_new (TYPE_GESTURES_XIAOMI, NULL);
+}
+
+gboolean
+gestures_xiaomi_supported (void)
+{
+    if (access (TOUCHPANEL_DT2W_NODE, F_OK) == 0)
+        return TRUE;
+
+    // TODO: do other checks?
+    return FALSE;
+}

--- a/system/gestures-xiaomi.h
+++ b/system/gestures-xiaomi.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright Eugenio Paolantonio (g7) <me@medesimo.eu>
+ */
+
+#ifndef GESTURESXIAOMI_H
+#define GESTURESXIAOMI_H
+
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define TYPE_GESTURES_XIAOMI gestures_xiaomi_get_type ()
+G_DECLARE_FINAL_TYPE (GesturesXiaomi, gestures_xiaomi, GESTURES, XIAOMI, GObject)
+
+GesturesXiaomi *gestures_xiaomi_new (void);
+gboolean gestures_xiaomi_supported (void);
+
+G_END_DECLS
+
+#endif /* GESTURESXIAOMI_H */

--- a/system/gestures.c
+++ b/system/gestures.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright Eugenio Paolantonio (g7) <me@medesimo.eu>
+ */
+
+#define G_LOG_DOMAIN "gestures-interface"
+
+#include "gestures.h"
+
+G_DEFINE_INTERFACE (Gestures, gestures, G_TYPE_OBJECT)
+
+static void
+gestures_default_init (GesturesInterface *iface)
+{
+    g_object_interface_install_property (iface,
+                                         g_param_spec_boolean ("double-tap-to-wake-supported",
+                                                               "double-tap-to-wake-supported",
+                                                               "Whether the device supports double tap to wake",
+                                                               FALSE,
+                                                               G_PARAM_READABLE));
+    g_object_interface_install_property (iface,
+                                         g_param_spec_boolean ("double-tap-to-wake-enabled",
+                                                               "double-tap-to-wake-enabled",
+                                                               "Whether double tap to wake is enabled",
+                                                               FALSE,
+                                                               G_PARAM_READABLE | G_PARAM_WRITABLE));
+}

--- a/system/gestures.h
+++ b/system/gestures.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright Eugenio Paolantonio (g7) <me@medesimo.eu>
+ */
+
+#ifndef GESTURES_H
+#define GESTURES_H
+
+#include <glib.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define TYPE_GESTURES gestures_get_type ()
+G_DECLARE_INTERFACE (Gestures, gestures, GESTURES, IFACE, GObject)
+
+struct _GesturesInterface
+{
+  GTypeInterface parent_iface;
+};
+
+G_END_DECLS
+
+#endif /* GESTURES_H */

--- a/system/meson.build
+++ b/system/meson.build
@@ -1,6 +1,7 @@
 mobile_settings_sources = [
   'bus.c',
   'gestures.c',
+  'gestures-xiaomi.c',
   'main.c',
   '../common/utils.c'
 ]

--- a/system/meson.build
+++ b/system/meson.build
@@ -2,6 +2,7 @@ mobile_settings_sources = [
   'bus.c',
   'gestures.c',
   'gestures-xiaomi.c',
+  'gestures-sec.c',
   'main.c',
   '../common/utils.c'
 ]

--- a/system/meson.build
+++ b/system/meson.build
@@ -1,5 +1,6 @@
 mobile_settings_sources = [
   'bus.c',
+  'gestures.c',
   'main.c',
   '../common/utils.c'
 ]


### PR DESCRIPTION
This PR moves device-specific gestures handling to separate objects, all using the `Gestures` gobject interface.

The existing double tap support has been moved to the `GesturesXiaomi` object.

A new one (`GesturesSec`) has been added for Samsung touchscreens using the `sec_ts` driver.

I think we can expand this in future with new gestures (Xperia 5 for example supports "glove mode" that could be useful).